### PR TITLE
feat: 상담 목록 조회 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,13 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/com/consultant/application/config/QueryDslConfig.java
+++ b/src/main/java/com/consultant/application/config/QueryDslConfig.java
@@ -1,0 +1,17 @@
+package com.consultant.application.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() { return new JPAQueryFactory(entityManager);}
+}

--- a/src/main/java/com/consultant/application/controller/ConsultingController.java
+++ b/src/main/java/com/consultant/application/controller/ConsultingController.java
@@ -10,6 +10,8 @@ import com.consultant.application.service.consulting.ModifyConsultingService;
 import com.consultant.application.service.consulting.RegisterConsultingService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -38,11 +40,18 @@ public class ConsultingController {
         return ResponseEntity.ok(consultingModifyResponse);
     }
 
-    
+
     @GetMapping("/{consultingId}/{managerId}")
     public ResponseEntity<Object> consultDetails(@PathVariable("consultingId")Long consultingId, @PathVariable("managerId") String managerId ) {
         ConsultingModifyResponse consultingModifyResponse = ConsultingModifyResponse.of(findConsultingService.findConsulting(consultingId, managerId));
         return ResponseEntity.ok(consultingModifyResponse);
+    }
+
+    @GetMapping("")
+    public ResponseEntity<Object> consultingList(@RequestParam String consultantId, @RequestParam String managerId, @RequestParam Boolean isReading,
+                                                 @RequestParam Boolean isFeedback, @RequestParam Boolean consultingDateAsc, Pageable pageable) {
+        Page<Consulting> consultingPage = findConsultingService.findConsultingPage(consultantId, managerId, isReading, isFeedback, consultingDateAsc, pageable);
+        return ResponseEntity.ok(consultingPage);
     }
 
 }

--- a/src/main/java/com/consultant/application/dao/ConsultingDao.java
+++ b/src/main/java/com/consultant/application/dao/ConsultingDao.java
@@ -7,6 +7,8 @@ import com.consultant.application.exception.ErrorConstant;
 import com.consultant.application.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.util.function.Supplier;
@@ -26,6 +28,10 @@ public class ConsultingDao {
      */
     public Consulting findByIdWithFetchJoinAllProperties(Long id) {
         return consultingRepository.findByIdWithFetchJoinAllProperties(id).orElseThrow(ExceptionHandler.notFound(id));
+    }
+
+    public Page<Consulting> findConsultingPagination(String consultantId, String managerId, Boolean isReading, Boolean isFeedback, Boolean consultingDateAsc, Pageable pageable){
+        return consultingRepository.findConsultingList(consultantId, managerId, isReading, isFeedback, consultingDateAsc, pageable);
     }
 
     private static class ExceptionHandler {

--- a/src/main/java/com/consultant/application/entity/consulting/ConsultingRepository.java
+++ b/src/main/java/com/consultant/application/entity/consulting/ConsultingRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface ConsultingRepository extends JpaRepository<Consulting, Long> {
+public interface ConsultingRepository extends JpaRepository<Consulting, Long>, CustomConsultingRepository {
 
     @Query("SELECT c FROM Consulting c JOIN FETCH ALL PROPERTIES WHERE c.id = :id")
     Optional<Consulting> findByIdWithFetchJoinAllProperties(@Param("id") Long id);

--- a/src/main/java/com/consultant/application/entity/consulting/CustomConsultingRepository.java
+++ b/src/main/java/com/consultant/application/entity/consulting/CustomConsultingRepository.java
@@ -1,0 +1,8 @@
+package com.consultant.application.entity.consulting;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomConsultingRepository {
+    Page<Consulting> findConsultingList(String consultantId, String managerId, Boolean isReading, Boolean isFeedback, Boolean consultingDateAsc, Pageable pageable);
+}

--- a/src/main/java/com/consultant/application/entity/consulting/CustomConsultingRepositoryImpl.java
+++ b/src/main/java/com/consultant/application/entity/consulting/CustomConsultingRepositoryImpl.java
@@ -1,0 +1,94 @@
+package com.consultant.application.entity.consulting;
+
+import com.consultant.application.entity.staff.QStaff;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.BooleanPath;
+import com.querydsl.core.types.dsl.StringPath;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+
+@RequiredArgsConstructor
+@Repository
+public class CustomConsultingRepositoryImpl implements CustomConsultingRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<Consulting> findConsultingList(String consultantId, String managerId, Boolean isReading, Boolean isFeedback, Boolean consultingDateAsc, Pageable pageable) {
+        QConsulting consulting = QConsulting.consulting;
+
+        JPAQuery<Consulting> consultingJPAQuery = jpaQueryFactory.select(consulting)
+                .where(eqConsultantId(consultantId), eqManagerId(managerId), eqIsRead(isReading), eqIsFeedback(isFeedback))
+                .orderBy(orderByAsc(consultingDateAsc)).offset(pageable.getOffset()).limit(pageable.getPageSize());
+
+        Long elementsNum = countElements(consultantId, managerId, isReading, isFeedback);
+
+        return new PageImpl<>(consultingJPAQuery.fetch(), pageable, elementsNum);
+    }
+
+    private Long countElements(String consultantId, String managerId, Boolean isReading, Boolean isFeedback) {
+        QConsulting consulting = QConsulting.consulting;
+
+        JPAQuery<Long> countTotalQuery = jpaQueryFactory.select(consulting.count())
+                .where(eqConsultantId(consultantId), eqManagerId(managerId), eqIsRead(isReading), eqIsFeedback(isFeedback));
+
+        return countTotalQuery.fetchFirst();
+
+    }
+
+    private BooleanExpression eqConsultantId(String consultantId) {
+        if(consultantId == null)
+            return null;
+
+        QStaff consultant = QConsulting.consulting.consultant;
+        return consultant.id.eq(consultantId);
+
+    }
+
+    private BooleanExpression eqManagerId(String managerId) {
+        if(managerId == null)
+            return null;
+
+        QStaff manager = QConsulting.consulting.manager;
+        return manager.id.eq(managerId);
+    }
+
+    private BooleanExpression eqIsRead(Boolean isReading) {
+
+        if(isReading == null) {
+            return null;
+        }
+
+        BooleanPath qIsReading = QConsulting.consulting.isReading;
+        return qIsReading.eq(isReading);
+    }
+
+    private BooleanExpression eqIsFeedback(Boolean isFeedback) {
+        if(isFeedback == null) {
+            return null;
+        }
+        StringPath qFeedback = QConsulting.consulting.feedback;
+        if(isFeedback) {
+            return qFeedback.isNotNull();
+        }
+        return qFeedback.isNull();
+    }
+
+    private OrderSpecifier<LocalDateTime> orderByAsc(Boolean consultingDateAsc) {
+        QConsulting consulting = QConsulting.consulting;
+        if(consultingDateAsc == null || !consultingDateAsc) {
+            return consulting.createdAt.desc();
+        }
+        return consulting.createdAt.asc();
+    }
+
+}

--- a/src/main/java/com/consultant/application/service/consulting/FindConsultingService.java
+++ b/src/main/java/com/consultant/application/service/consulting/FindConsultingService.java
@@ -2,7 +2,11 @@ package com.consultant.application.service.consulting;
 
 
 import com.consultant.application.entity.consulting.Consulting;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface FindConsultingService {
     Consulting findConsulting(Long consultingId, String managerId);
+
+    Page<Consulting> findConsultingPage(String consultantId, String managerId, Boolean isReading, Boolean isFeedback, Boolean consultingDateAsc, Pageable pageable);
 }

--- a/src/main/java/com/consultant/application/service/consulting/FindConsultingServiceImpl.java
+++ b/src/main/java/com/consultant/application/service/consulting/FindConsultingServiceImpl.java
@@ -3,6 +3,8 @@ package com.consultant.application.service.consulting;
 import com.consultant.application.dao.ConsultingDao;
 import com.consultant.application.entity.consulting.Consulting;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -18,5 +20,10 @@ public class FindConsultingServiceImpl implements FindConsultingService{
             consulting.read();
 
         return consulting;
+    }
+
+    @Override
+    public Page<Consulting> findConsultingPage(String consultantId, String managerId, Boolean isReading, Boolean isFeedback, Boolean consultingDateAsc, Pageable pageable) {
+        return consultingDao.findConsultingPagination(consultantId, managerId, isReading, isFeedback, consultingDateAsc, pageable);
     }
 }


### PR DESCRIPTION
QueryDSL로 동적쿼리를 활용

- 정렬
  상담일시 (오름차순 내림차순), default : 내림차순
- 필터
  상담자ID, 담당자ID, 담당자 읽음 여부, 피드백 내용 유무 여부